### PR TITLE
Render Success Message for saveCurrentMatch

### DIFF
--- a/src/components/UserResults/UserResults.jsx
+++ b/src/components/UserResults/UserResults.jsx
@@ -10,10 +10,10 @@ function UserResults({ matchResults, saveMatch }) {
     const goToProfile = () => navigate("/profile")
 
     const saveCurrentMatch = () => {
-       saveMatch(matchResults)
-      }
+        saveMatch(matchResults)
+        }
 
-   
+
     const handleZipSubmit = (e) => {
         e.preventDefault()
         navigate("/petfinder", {

--- a/src/components/UserResults/UserResults.jsx
+++ b/src/components/UserResults/UserResults.jsx
@@ -12,8 +12,12 @@ function UserResults({ matchResults, saveMatch }) {
 
     const saveCurrentMatch = () => {
         saveMatch(matchResults)
-        }
-
+        setAlertMessage("Your pet was successfully saved!")
+    
+        setTimeout(() => {
+            setAlertMessage("");
+        }, 3000);
+    }
 
     const handleZipSubmit = (e) => {
         e.preventDefault()

--- a/src/components/UserResults/UserResults.jsx
+++ b/src/components/UserResults/UserResults.jsx
@@ -43,6 +43,8 @@ function UserResults({ matchResults, saveMatch }) {
                 <p>{matchResults.type}</p>
                 <img src={matchResults.photo_url} alt={`A cute little ${matchResults.type}`} />
                 <button onClick={saveCurrentMatch}>Save Pet</button>
+
+                {alertMessage ? <p>{alertMessage}</p> : null}
             </section>
             <section>
                 <form onSubmit={handleZipSubmit}>

--- a/src/components/UserResults/UserResults.jsx
+++ b/src/components/UserResults/UserResults.jsx
@@ -8,6 +8,7 @@ function UserResults({ matchResults, saveMatch }) {
     const navigate = useNavigate()
     const goHome = () => navigate("/welcome")
     const goToProfile = () => navigate("/profile")
+    const [alertMessage, setAlertMessage] = useState("")
 
     const saveCurrentMatch = () => {
         saveMatch(matchResults)


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] New feature
- [ ] Bug Fix

## Check the correct boxes

- [x] This code broke nothing
- [ ] This code broke some stuff
- [ ] This code broke everything

## Implements/Fixes

- Added success alert message below the “Save Pet” button on UserResults page
- Alert displays for 3 seconds after saving a pet
- Closes #26 

## Testing Changes

- [ ] I have fully tested my code
- [ ] All tests are passing
- [ ] Some tests are failing
- [ ] All tests are failing

- [x] No previous tests have been changed
- [ ] Some previous tests have been changed
- [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

## Checklist

- [x] I have reviewed my code
- [x] The code will run locally

## (Optional) What questions do you have? Anything specific you want feedback on?

- I tested this user flow locally on the frontend server. The success message renders correctly beneath the “Save Pet” button and disappears after the intended 3-second timeout.

- I have not yet added or updated any Cypress tests to check for this behavior.

- Should we consider displaying a separate alert (e.g. “This pet has already been saved”) to inform users when they’ve attempted to save a duplicate? Or is duplicate prevention handled sufficiently on the backend?

![Link](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmU0dHB0OWp1cHU2Mnl3dDQ2ZnNqZTZxeTk2czlhOTh5OWU3NW90ZiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3BRDkVjKikYW4/giphy.gif)
